### PR TITLE
Surface the no flush flavor of `set_state`

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -109,6 +109,13 @@ pub unsafe extern "C" fn bochscpu_cpu_set_state(p: bochscpu_cpu_t, s: *const boc
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn bochscpu_cpu_set_state_no_flush(p: bochscpu_cpu_t, s: *const bochscpu_cpu_state_t) {
+    let c: ManuallyDrop<Box<Cpu>> = ManuallyDrop::new(Box::from_raw(p as _));
+
+    c.set_state_no_flush(&*s)
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn bochscpu_cpu_set_exception(p: bochscpu_cpu_t, vector: u32, error: u16) {
     let c: ManuallyDrop<Box<Cpu>> = ManuallyDrop::new(Box::from_raw(p as _));
 


### PR DESCRIPTION
With flushing:
```c++
// Run stats:
//          Memory accesses: 34.1gb
// # instructions executed: 353.4m
//     total time emulating: 25.4min
//           # instructions / s: 231.6k
//   crashes/timeouts/oks: 107.0m/237.1k/0.0
  ```
  
  Without flushing:
  ```c++
// Run stats:
//         Memory accesses: 3.7gb
// # instructions executed: 353.4m
//    total time emulating: 5.3min
//      # instructions / s: 1.1m
//    crashes/timeouts/oks: 107.0m/237.1k/0.0
```